### PR TITLE
Added 'sp_ng_template' as a table possible to be synchronised

### DIFF
--- a/config/default_config.json
+++ b/config/default_config.json
@@ -60,6 +60,12 @@
       "key": "id",
       "field": "script",
       "extension": "js"
+    },
+    "ng_template": {
+      "table": "sp_ng_template",
+      "key": "id",
+      "field": "template",
+      "extension": "html"
     }
   }
 }


### PR DESCRIPTION
'sp_ng_template' is a table used to store "Angular ng_templates". This contains HTML templates which can be included via ngInclude. This change allows this table to be synchonised. See https://docs.angularjs.org/api/ng/directive/ngInclude for further information about ngInclude.